### PR TITLE
Ensure git is present from preinstall script

### DIFF
--- a/preinstall.sh
+++ b/preinstall.sh
@@ -48,7 +48,7 @@
     sudo apt update && sudo apt upgrade -y
     ## Install svxlink-server  and dependencies ##
     echo -e "${BLUE}#### Installing svxlink-server #### ${WHITE}" | sudo tee -a /var/log/install.log
-    sudo apt install -y curl svxlink-server qtel apache2 apache2-bin apache2-data apache2-utils php8.2 python3-serial sqlite3 libssl-dev php8.2-sqlite3 toilet libgpiod-dev --fix-missing -y
+    sudo apt install --fix-missing -y curl svxlink-server qtel apache2 apache2-bin apache2-data apache2-utils php8.2 python3-serial sqlite3 libssl-dev php8.2-sqlite3 toilet libgpiod-dev git
     echo -e "${BLUE}#### Installing locales #### ${WHITE}" | sudo tee -a /var/log/install.log
     
     ## Must kill the remotetrx.service to avoid a problem later ##


### PR DESCRIPTION
I was trying a fresh install from a copy of the repo that I'd copied up with `rsync` (with some local changes), neglecting to install `git` first.

`install.sh` failed following the reboot as `git` was not present.

It occurred to me that users may download a ZIP file of the repository and copy up to their device, similar to what I had done, so it makes sense to ensure that `git` is installed with the preinstall script. If it is already there then no additional action is taken.

While there I also removed the extra `-y` and moved `--fix-missing` nearer the start of the line to sit with the other switch.

73

Matt G4IYT